### PR TITLE
Remove rule name

### DIFF
--- a/src/reporting1/format1.js
+++ b/src/reporting1/format1.js
@@ -141,110 +141,91 @@ function peg$parse(input, options) {
       peg$startRuleFunctions = { start: peg$parsestart },
       peg$startRuleFunction  = peg$parsestart,
 
-      peg$c0 = peg$otherExpectation("report"),
-      peg$c1 = "report",
-      peg$c2 = peg$literalExpectation("report", false),
-      peg$c3 = "{",
-      peg$c4 = peg$literalExpectation("{", false),
-      peg$c5 = "}",
-      peg$c6 = peg$literalExpectation("}", false),
-      peg$c7 = function(codes, outputs) {
+      peg$c0 = "report",
+      peg$c1 = peg$literalExpectation("report", false),
+      peg$c2 = "{",
+      peg$c3 = peg$literalExpectation("{", false),
+      peg$c4 = "}",
+      peg$c5 = peg$literalExpectation("}", false),
+      peg$c6 = function(codes, outputs) {
           return {
             code: codes,
             output: outputs,
           };
         },
-      peg$c8 = peg$otherExpectation("code_block"),
-      peg$c9 = "code",
-      peg$c10 = peg$literalExpectation("code", false),
-      peg$c11 = function(codes) {
+      peg$c7 = "code",
+      peg$c8 = peg$literalExpectation("code", false),
+      peg$c9 = function(codes) {
           return codes;
         },
-      peg$c12 = peg$otherExpectation("code_block_line"),
-      peg$c13 = function(c) {
+      peg$c10 = function(c) {
           return c;
         },
-      peg$c14 = peg$otherExpectation("code"),
-      peg$c15 = /^[0-9]/,
-      peg$c16 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c17 = peg$otherExpectation("output_block"),
-      peg$c18 = "output",
-      peg$c19 = peg$literalExpectation("output", false),
-      peg$c20 = function(outputs) {
+      peg$c11 = /^[0-9]/,
+      peg$c12 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c13 = "output",
+      peg$c14 = peg$literalExpectation("output", false),
+      peg$c15 = function(outputs) {
           return outputs;
         },
-      peg$c21 = peg$otherExpectation("output_block_element"),
-      peg$c22 = peg$otherExpectation("output_line"),
-      peg$c23 = "'",
-      peg$c24 = peg$literalExpectation("'", false),
-      peg$c25 = function(t) {
+      peg$c16 = "'",
+      peg$c17 = peg$literalExpectation("'", false),
+      peg$c18 = function(t) {
           return {
             type: 'builtin',
             text: 'output_line',
             children: t,
           };
         },
-      peg$c26 = "\"",
-      peg$c27 = peg$literalExpectation("\"", false),
-      peg$c28 = peg$otherExpectation("item_code"),
-      peg$c29 = function() {
+      peg$c19 = "\"",
+      peg$c20 = peg$literalExpectation("\"", false),
+      peg$c21 = function() {
           return {
             type: 'variable',
             text: 'code',
           };
         },
-      peg$c30 = peg$otherExpectation("item_name"),
-      peg$c31 = "name",
-      peg$c32 = peg$literalExpectation("name", false),
-      peg$c33 = function() {
+      peg$c22 = "name",
+      peg$c23 = peg$literalExpectation("name", false),
+      peg$c24 = function() {
           return {
             type: 'variable',
             text: 'name',
           };
         },
-      peg$c34 = peg$otherExpectation("item_amount"),
-      peg$c35 = "amount",
-      peg$c36 = peg$literalExpectation("amount", false),
-      peg$c37 = function() {
+      peg$c25 = "amount",
+      peg$c26 = peg$literalExpectation("amount", false),
+      peg$c27 = function() {
           return {
             type: 'variable',
             text: 'amount',
           };
         },
-      peg$c38 = peg$otherExpectation("placeholder_open"),
-      peg$c39 = peg$anyExpectation(),
-      peg$c40 = function(w) { return w === placeholder_mark; },
-      peg$c41 = function(w) {
+      peg$c28 = peg$anyExpectation(),
+      peg$c29 = function(w) { return w === placeholder_mark; },
+      peg$c30 = function(w) {
           return w;
         },
-      peg$c42 = peg$otherExpectation("bracket_open"),
-      peg$c43 = function(w) { return w === bracket_open; },
-      peg$c44 = peg$otherExpectation("bracket_close"),
-      peg$c45 = function(w) { return w === bracket_close; },
-      peg$c46 = peg$otherExpectation("text_single_quote"),
-      peg$c47 = function(chars) {
+      peg$c31 = function(w) { return w === bracket_open; },
+      peg$c32 = function(w) { return w === bracket_close; },
+      peg$c33 = function(chars) {
           return {
             type: 'plain',
             text: chars.join(''),
           };
         },
-      peg$c48 = peg$otherExpectation("text_single_quote_char"),
-      peg$c49 = /^[^\r\n']/,
-      peg$c50 = peg$classExpectation(["\r", "\n", "'"], true, false),
-      peg$c51 = function(char) { return char !== placeholder_mark; },
-      peg$c52 = function(char) {
+      peg$c34 = /^[^\r\n']/,
+      peg$c35 = peg$classExpectation(["\r", "\n", "'"], true, false),
+      peg$c36 = function(char) { return char !== placeholder_mark; },
+      peg$c37 = function(char) {
           return char;
         },
-      peg$c53 = peg$otherExpectation("text_double_quote"),
-      peg$c54 = peg$otherExpectation("text_double_quote_char"),
-      peg$c55 = /^[^\r\n"]/,
-      peg$c56 = peg$classExpectation(["\r", "\n", "\""], true, false),
-      peg$c57 = peg$otherExpectation("whitespace"),
-      peg$c58 = /^[ \t]/,
-      peg$c59 = peg$classExpectation([" ", "\t"], false, false),
-      peg$c60 = peg$otherExpectation("newline"),
-      peg$c61 = /^[\r\n]/,
-      peg$c62 = peg$classExpectation(["\r", "\n"], false, false),
+      peg$c38 = /^[^\r\n"]/,
+      peg$c39 = peg$classExpectation(["\r", "\n", "\""], true, false),
+      peg$c40 = /^[ \t]/,
+      peg$c41 = peg$classExpectation([" ", "\t"], false, false),
+      peg$c42 = /^[\r\n]/,
+      peg$c43 = peg$classExpectation(["\r", "\n"], false, false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -402,26 +383,25 @@ function peg$parse(input, options) {
   function peg$parsereport() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c1) {
-        s2 = peg$c1;
+      if (input.substr(peg$currPos, 6) === peg$c0) {
+        s2 = peg$c0;
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c2); }
+        if (peg$silentFails === 0) { peg$fail(peg$c1); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 123) {
-            s4 = peg$c3;
+            s4 = peg$c2;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c4); }
+            if (peg$silentFails === 0) { peg$fail(peg$c3); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -435,11 +415,11 @@ function peg$parse(input, options) {
                     s9 = peg$parse_();
                     if (s9 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 125) {
-                        s10 = peg$c5;
+                        s10 = peg$c4;
                         peg$currPos++;
                       } else {
                         s10 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c6); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c5); }
                       }
                       if (s10 !== peg$FAILED) {
                         s11 = peg$parse_();
@@ -452,7 +432,7 @@ function peg$parse(input, options) {
                           }
                           if (s12 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c7(s7, s8);
+                            s1 = peg$c6(s7, s8);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -502,11 +482,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c0); }
-    }
 
     return s0;
   }
@@ -514,26 +489,25 @@ function peg$parse(input, options) {
   function peg$parsecode_block() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c9) {
-        s2 = peg$c9;
+      if (input.substr(peg$currPos, 4) === peg$c7) {
+        s2 = peg$c7;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c10); }
+        if (peg$silentFails === 0) { peg$fail(peg$c8); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 123) {
-            s4 = peg$c3;
+            s4 = peg$c2;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c4); }
+            if (peg$silentFails === 0) { peg$fail(peg$c3); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -554,11 +528,11 @@ function peg$parse(input, options) {
                   s8 = peg$parse_();
                   if (s8 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 125) {
-                      s9 = peg$c5;
+                      s9 = peg$c4;
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c6); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c5); }
                     }
                     if (s9 !== peg$FAILED) {
                       s10 = peg$parse_();
@@ -566,7 +540,7 @@ function peg$parse(input, options) {
                         s11 = peg$parsenewline();
                         if (s11 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c11(s7);
+                          s1 = peg$c9(s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -612,11 +586,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c8); }
-    }
 
     return s0;
   }
@@ -624,7 +593,6 @@ function peg$parse(input, options) {
   function peg$parsecode_block_line() {
     var s0, s1, s2, s3, s4;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
@@ -635,7 +603,7 @@ function peg$parse(input, options) {
           s4 = peg$parsenewline();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c13(s2);
+            s1 = peg$c10(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -653,11 +621,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c12); }
-    }
 
     return s0;
   }
@@ -665,25 +628,24 @@ function peg$parse(input, options) {
   function peg$parsecode() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c15.test(input.charAt(peg$currPos))) {
+    if (peg$c11.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c16); }
+      if (peg$silentFails === 0) { peg$fail(peg$c12); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c15.test(input.charAt(peg$currPos))) {
+        if (peg$c11.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c16); }
+          if (peg$silentFails === 0) { peg$fail(peg$c12); }
         }
       }
     } else {
@@ -694,11 +656,6 @@ function peg$parse(input, options) {
     } else {
       s0 = s1;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c14); }
-    }
 
     return s0;
   }
@@ -706,26 +663,25 @@ function peg$parse(input, options) {
   function peg$parseoutput_block() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c18) {
-        s2 = peg$c18;
+      if (input.substr(peg$currPos, 6) === peg$c13) {
+        s2 = peg$c13;
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c19); }
+        if (peg$silentFails === 0) { peg$fail(peg$c14); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 123) {
-            s4 = peg$c3;
+            s4 = peg$c2;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c4); }
+            if (peg$silentFails === 0) { peg$fail(peg$c3); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -733,11 +689,11 @@ function peg$parse(input, options) {
               s6 = peg$parsenewline();
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                s8 = peg$parseoutput_block_element();
+                s8 = peg$parseoutput_line();
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    s8 = peg$parseoutput_block_element();
+                    s8 = peg$parseoutput_line();
                   }
                 } else {
                   s7 = peg$FAILED;
@@ -746,11 +702,11 @@ function peg$parse(input, options) {
                   s8 = peg$parse_();
                   if (s8 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 125) {
-                      s9 = peg$c5;
+                      s9 = peg$c4;
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c6); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c5); }
                     }
                     if (s9 !== peg$FAILED) {
                       s10 = peg$parse_();
@@ -758,7 +714,7 @@ function peg$parse(input, options) {
                         s11 = peg$parsenewline();
                         if (s11 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c20(s7);
+                          s1 = peg$c15(s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -804,25 +760,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c17); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseoutput_block_element() {
-    var s0, s1;
-
-    peg$silentFails++;
-    s0 = peg$parseoutput_line();
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c21); }
-    }
 
     return s0;
   }
@@ -830,16 +767,15 @@ function peg$parse(input, options) {
   function peg$parseoutput_line() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 39) {
-        s2 = peg$c23;
+        s2 = peg$c16;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c24); }
+        if (peg$silentFails === 0) { peg$fail(peg$c17); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
@@ -868,11 +804,11 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s4 = peg$c23;
+            s4 = peg$c16;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c24); }
+            if (peg$silentFails === 0) { peg$fail(peg$c17); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -880,7 +816,7 @@ function peg$parse(input, options) {
               s6 = peg$parsenewline();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c25(s3);
+                s1 = peg$c18(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -911,11 +847,11 @@ function peg$parse(input, options) {
       s1 = peg$parse_();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s2 = peg$c26;
+          s2 = peg$c19;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c27); }
+          if (peg$silentFails === 0) { peg$fail(peg$c20); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
@@ -944,11 +880,11 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 34) {
-              s4 = peg$c26;
+              s4 = peg$c19;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c27); }
+              if (peg$silentFails === 0) { peg$fail(peg$c20); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -956,7 +892,7 @@ function peg$parse(input, options) {
                 s6 = peg$parsenewline();
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c25(s3);
+                  s1 = peg$c18(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -983,11 +919,6 @@ function peg$parse(input, options) {
         s0 = peg$FAILED;
       }
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c22); }
-    }
 
     return s0;
   }
@@ -995,7 +926,6 @@ function peg$parse(input, options) {
   function peg$parseitem_code() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parseplaceholder_open();
     if (s1 !== peg$FAILED) {
@@ -1003,12 +933,12 @@ function peg$parse(input, options) {
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 4) === peg$c9) {
-            s4 = peg$c9;
+          if (input.substr(peg$currPos, 4) === peg$c7) {
+            s4 = peg$c7;
             peg$currPos += 4;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c10); }
+            if (peg$silentFails === 0) { peg$fail(peg$c8); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -1016,7 +946,7 @@ function peg$parse(input, options) {
               s6 = peg$parsebracket_close();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c29();
+                s1 = peg$c21();
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1041,11 +971,6 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c28); }
     }
 
     return s0;
@@ -1054,7 +979,6 @@ function peg$parse(input, options) {
   function peg$parseitem_name() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parseplaceholder_open();
     if (s1 !== peg$FAILED) {
@@ -1062,12 +986,12 @@ function peg$parse(input, options) {
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 4) === peg$c31) {
-            s4 = peg$c31;
+          if (input.substr(peg$currPos, 4) === peg$c22) {
+            s4 = peg$c22;
             peg$currPos += 4;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c32); }
+            if (peg$silentFails === 0) { peg$fail(peg$c23); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -1075,7 +999,7 @@ function peg$parse(input, options) {
               s6 = peg$parsebracket_close();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c33();
+                s1 = peg$c24();
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1100,11 +1024,6 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c30); }
     }
 
     return s0;
@@ -1113,7 +1032,6 @@ function peg$parse(input, options) {
   function peg$parseitem_amount() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parseplaceholder_open();
     if (s1 !== peg$FAILED) {
@@ -1121,12 +1039,12 @@ function peg$parse(input, options) {
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c35) {
-            s4 = peg$c35;
+          if (input.substr(peg$currPos, 6) === peg$c25) {
+            s4 = peg$c25;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c36); }
+            if (peg$silentFails === 0) { peg$fail(peg$c26); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -1134,7 +1052,7 @@ function peg$parse(input, options) {
               s6 = peg$parsebracket_close();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c37();
+                s1 = peg$c27();
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1160,11 +1078,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c34); }
-    }
 
     return s0;
   }
@@ -1172,18 +1085,17 @@ function peg$parse(input, options) {
   function peg$parseplaceholder_open() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     if (input.length > peg$currPos) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c39); }
+      if (peg$silentFails === 0) { peg$fail(peg$c28); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c40(s1);
+      s2 = peg$c29(s1);
       if (s2) {
         s2 = void 0;
       } else {
@@ -1191,7 +1103,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c41(s1);
+        s1 = peg$c30(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1200,11 +1112,6 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c38); }
     }
 
     return s0;
@@ -1213,18 +1120,17 @@ function peg$parse(input, options) {
   function peg$parsebracket_open() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     if (input.length > peg$currPos) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c39); }
+      if (peg$silentFails === 0) { peg$fail(peg$c28); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c43(s1);
+      s2 = peg$c31(s1);
       if (s2) {
         s2 = void 0;
       } else {
@@ -1232,7 +1138,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c41(s1);
+        s1 = peg$c30(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1241,11 +1147,6 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c42); }
     }
 
     return s0;
@@ -1254,18 +1155,17 @@ function peg$parse(input, options) {
   function peg$parsebracket_close() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     if (input.length > peg$currPos) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c39); }
+      if (peg$silentFails === 0) { peg$fail(peg$c28); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c45(s1);
+      s2 = peg$c32(s1);
       if (s2) {
         s2 = void 0;
       } else {
@@ -1273,7 +1173,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c41(s1);
+        s1 = peg$c30(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1283,11 +1183,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c44); }
-    }
 
     return s0;
   }
@@ -1295,7 +1190,6 @@ function peg$parse(input, options) {
   function peg$parsetext_single_quote() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = [];
     s2 = peg$parsetext_single_quote_char();
@@ -1309,14 +1203,9 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c47(s1);
+      s1 = peg$c33(s1);
     }
     s0 = s1;
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c46); }
-    }
 
     return s0;
   }
@@ -1324,18 +1213,17 @@ function peg$parse(input, options) {
   function peg$parsetext_single_quote_char() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
-    if (peg$c49.test(input.charAt(peg$currPos))) {
+    if (peg$c34.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c50); }
+      if (peg$silentFails === 0) { peg$fail(peg$c35); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c51(s1);
+      s2 = peg$c36(s1);
       if (s2) {
         s2 = void 0;
       } else {
@@ -1343,7 +1231,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c52(s1);
+        s1 = peg$c37(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1353,11 +1241,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c48); }
-    }
 
     return s0;
   }
@@ -1365,7 +1248,6 @@ function peg$parse(input, options) {
   function peg$parsetext_double_quote() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = [];
     s2 = peg$parsetext_double_quote_char();
@@ -1379,14 +1261,9 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c47(s1);
+      s1 = peg$c33(s1);
     }
     s0 = s1;
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c53); }
-    }
 
     return s0;
   }
@@ -1394,18 +1271,17 @@ function peg$parse(input, options) {
   function peg$parsetext_double_quote_char() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
-    if (peg$c55.test(input.charAt(peg$currPos))) {
+    if (peg$c38.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c56); }
+      if (peg$silentFails === 0) { peg$fail(peg$c39); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c51(s1);
+      s2 = peg$c36(s1);
       if (s2) {
         s2 = void 0;
       } else {
@@ -1413,7 +1289,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c52(s1);
+        s1 = peg$c37(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1423,11 +1299,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
-    }
 
     return s0;
   }
@@ -1435,29 +1306,23 @@ function peg$parse(input, options) {
   function peg$parse_() {
     var s0, s1;
 
-    peg$silentFails++;
     s0 = [];
-    if (peg$c58.test(input.charAt(peg$currPos))) {
+    if (peg$c40.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c59); }
+      if (peg$silentFails === 0) { peg$fail(peg$c41); }
     }
     while (s1 !== peg$FAILED) {
       s0.push(s1);
-      if (peg$c58.test(input.charAt(peg$currPos))) {
+      if (peg$c40.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c59); }
+        if (peg$silentFails === 0) { peg$fail(peg$c41); }
       }
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c57); }
     }
 
     return s0;
@@ -1466,33 +1331,27 @@ function peg$parse(input, options) {
   function peg$parsenewline() {
     var s0, s1;
 
-    peg$silentFails++;
     s0 = [];
-    if (peg$c61.test(input.charAt(peg$currPos))) {
+    if (peg$c42.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c62); }
+      if (peg$silentFails === 0) { peg$fail(peg$c43); }
     }
     if (s1 !== peg$FAILED) {
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c61.test(input.charAt(peg$currPos))) {
+        if (peg$c42.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c62); }
+          if (peg$silentFails === 0) { peg$fail(peg$c43); }
         }
       }
     } else {
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c60); }
     }
 
     return s0;

--- a/src/reporting1/format1.pegjs
+++ b/src/reporting1/format1.pegjs
@@ -7,7 +7,7 @@
 start
   = report+
 
-report 'report'
+report
   = _ 'report' _ '{' _ newline
     codes:code_block
     outputs:output_block
@@ -19,7 +19,7 @@ report 'report'
     };
   }
 
-code_block 'code_block'
+code_block
   = _ 'code' _ '{' _ newline
     codes:code_block_line+
     _ '}' _ newline
@@ -27,16 +27,16 @@ code_block 'code_block'
     return codes;
   }
 
-code_block_line 'code_block_line'
+code_block_line
   = _ c:code _ newline
   {
     return c;
   }
 
-code 'code'
+code
   = $([0-9]+)
 
-output_block 'output_block'
+output_block
   = _ 'output' _ '{' _ newline
     outputs:output_block_element+
     _ '}' _ newline
@@ -44,10 +44,10 @@ output_block 'output_block'
     return outputs;
   }
 
-output_block_element 'output_block_element'
+output_block_element
   = output_line
 
-output_line 'output_line'
+output_line
   = _ "'" t:(item_code / item_name / item_amount / text_single_quote)* "'" _ newline
   {
     return {
@@ -65,7 +65,7 @@ output_line 'output_line'
     };
   }
 
-item_code 'item_code'
+item_code
   = placeholder_open bracket_open _ 'code' _ bracket_close
   {
     return {
@@ -74,7 +74,7 @@ item_code 'item_code'
     };
   }
 
-item_name 'item_name'
+item_name
   = placeholder_open bracket_open _ 'name' _ bracket_close
   {
     return {
@@ -83,7 +83,7 @@ item_name 'item_name'
     };
   }
 
-item_amount 'item_amount'
+item_amount
   = placeholder_open bracket_open _ 'amount' _ bracket_close
   {
     return {
@@ -92,28 +92,28 @@ item_amount 'item_amount'
     };
   }
 
-placeholder_open 'placeholder_open'
+placeholder_open
   = w:.
     &{ return w === placeholder_mark; }
   {
     return w;
   }
 
-bracket_open 'bracket_open'
+bracket_open
   = w:.
     &{ return w === bracket_open; }
   {
     return w;
   }
 
-bracket_close 'bracket_close'
+bracket_close
   = w:.
     &{ return w === bracket_close; }
   {
     return w;
   }
 
-text_single_quote 'text_single_quote'
+text_single_quote
   = chars:text_single_quote_char+
   {
     return {
@@ -122,14 +122,14 @@ text_single_quote 'text_single_quote'
     };
   }
 
-text_single_quote_char 'text_single_quote_char'
+text_single_quote_char
   = char:[^\r\n']
     &{ return char !== placeholder_mark; }
   {
     return char;
   }
 
-text_double_quote 'text_double_quote'
+text_double_quote
   = chars:text_double_quote_char+
   {
     return {
@@ -138,15 +138,15 @@ text_double_quote 'text_double_quote'
     };
   }
 
-text_double_quote_char 'text_double_quote_char'
+text_double_quote_char
   = char:[^\r\n"]
     &{ return char !== placeholder_mark; }
   {
     return char;
   }
 
-_ 'whitespace'
+_
   = [ \t]*
 
-newline 'newline'
+newline
   = [\r\n]+

--- a/src/reporting2/format2.js
+++ b/src/reporting2/format2.js
@@ -141,110 +141,91 @@ function peg$parse(input, options) {
       peg$startRuleFunctions = { start: peg$parsestart },
       peg$startRuleFunction  = peg$parsestart,
 
-      peg$c0 = peg$otherExpectation("report"),
-      peg$c1 = "report",
-      peg$c2 = peg$literalExpectation("report", false),
-      peg$c3 = "{",
-      peg$c4 = peg$literalExpectation("{", false),
-      peg$c5 = "}",
-      peg$c6 = peg$literalExpectation("}", false),
-      peg$c7 = function(codes, outputs) {
+      peg$c0 = "report",
+      peg$c1 = peg$literalExpectation("report", false),
+      peg$c2 = "{",
+      peg$c3 = peg$literalExpectation("{", false),
+      peg$c4 = "}",
+      peg$c5 = peg$literalExpectation("}", false),
+      peg$c6 = function(codes, outputs) {
           return {
             code: codes,
             output: outputs,
           };
         },
-      peg$c8 = peg$otherExpectation("code_block"),
-      peg$c9 = "code",
-      peg$c10 = peg$literalExpectation("code", false),
-      peg$c11 = function(codes) {
+      peg$c7 = "code",
+      peg$c8 = peg$literalExpectation("code", false),
+      peg$c9 = function(codes) {
           return codes;
         },
-      peg$c12 = peg$otherExpectation("code_block_line"),
-      peg$c13 = function(c) {
+      peg$c10 = function(c) {
           return c;
         },
-      peg$c14 = peg$otherExpectation("code"),
-      peg$c15 = /^[0-9]/,
-      peg$c16 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c17 = peg$otherExpectation("output_block"),
-      peg$c18 = "output",
-      peg$c19 = peg$literalExpectation("output", false),
-      peg$c20 = function(outputs) {
+      peg$c11 = /^[0-9]/,
+      peg$c12 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c13 = "output",
+      peg$c14 = peg$literalExpectation("output", false),
+      peg$c15 = function(outputs) {
           return outputs;
         },
-      peg$c21 = peg$otherExpectation("output_block_element"),
-      peg$c22 = peg$otherExpectation("output_line"),
-      peg$c23 = "'",
-      peg$c24 = peg$literalExpectation("'", false),
-      peg$c25 = function(t) {
+      peg$c16 = "'",
+      peg$c17 = peg$literalExpectation("'", false),
+      peg$c18 = function(t) {
           return {
             type: 'builtin',
             text: 'output_line',
             children: t,
           };
         },
-      peg$c26 = "\"",
-      peg$c27 = peg$literalExpectation("\"", false),
-      peg$c28 = peg$otherExpectation("item_code"),
-      peg$c29 = function() {
+      peg$c19 = "\"",
+      peg$c20 = peg$literalExpectation("\"", false),
+      peg$c21 = function() {
           return {
             type: 'variable',
             text: 'code',
           };
         },
-      peg$c30 = peg$otherExpectation("item_name"),
-      peg$c31 = "name",
-      peg$c32 = peg$literalExpectation("name", false),
-      peg$c33 = function() {
+      peg$c22 = "name",
+      peg$c23 = peg$literalExpectation("name", false),
+      peg$c24 = function() {
           return {
             type: 'variable',
             text: 'name',
           };
         },
-      peg$c34 = peg$otherExpectation("item_amount"),
-      peg$c35 = "amount",
-      peg$c36 = peg$literalExpectation("amount", false),
-      peg$c37 = function() {
+      peg$c25 = "amount",
+      peg$c26 = peg$literalExpectation("amount", false),
+      peg$c27 = function() {
           return {
             type: 'variable',
             text: 'amount',
           };
         },
-      peg$c38 = peg$otherExpectation("placeholder_open"),
-      peg$c39 = peg$anyExpectation(),
-      peg$c40 = function(w) { return w === placeholder_mark; },
-      peg$c41 = function(w) {
+      peg$c28 = peg$anyExpectation(),
+      peg$c29 = function(w) { return w === placeholder_mark; },
+      peg$c30 = function(w) {
           return w;
         },
-      peg$c42 = peg$otherExpectation("bracket_open"),
-      peg$c43 = function(w) { return w === bracket_open; },
-      peg$c44 = peg$otherExpectation("bracket_close"),
-      peg$c45 = function(w) { return w === bracket_close; },
-      peg$c46 = peg$otherExpectation("text_single_quote"),
-      peg$c47 = function(chars) {
+      peg$c31 = function(w) { return w === bracket_open; },
+      peg$c32 = function(w) { return w === bracket_close; },
+      peg$c33 = function(chars) {
           return {
             type: 'plain',
             text: chars.join(''),
           };
         },
-      peg$c48 = peg$otherExpectation("text_single_quote_char"),
-      peg$c49 = /^[^\r\n']/,
-      peg$c50 = peg$classExpectation(["\r", "\n", "'"], true, false),
-      peg$c51 = function(char) { return char !== placeholder_mark; },
-      peg$c52 = function(char) {
+      peg$c34 = /^[^\r\n']/,
+      peg$c35 = peg$classExpectation(["\r", "\n", "'"], true, false),
+      peg$c36 = function(char) { return char !== placeholder_mark; },
+      peg$c37 = function(char) {
           return char;
         },
-      peg$c53 = peg$otherExpectation("text_double_quote"),
-      peg$c54 = peg$otherExpectation("text_double_quote_char"),
-      peg$c55 = /^[^\r\n"]/,
-      peg$c56 = peg$classExpectation(["\r", "\n", "\""], true, false),
-      peg$c57 = peg$otherExpectation("whitespace"),
-      peg$c58 = /^[ \t]/,
-      peg$c59 = peg$classExpectation([" ", "\t"], false, false),
-      peg$c60 = peg$otherExpectation("newline"),
-      peg$c61 = /^[\r\n]/,
-      peg$c62 = peg$classExpectation(["\r", "\n"], false, false),
+      peg$c38 = /^[^\r\n"]/,
+      peg$c39 = peg$classExpectation(["\r", "\n", "\""], true, false),
+      peg$c40 = /^[ \t]/,
+      peg$c41 = peg$classExpectation([" ", "\t"], false, false),
+      peg$c42 = /^[\r\n]/,
+      peg$c43 = peg$classExpectation(["\r", "\n"], false, false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -402,26 +383,25 @@ function peg$parse(input, options) {
   function peg$parsereport() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c1) {
-        s2 = peg$c1;
+      if (input.substr(peg$currPos, 6) === peg$c0) {
+        s2 = peg$c0;
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c2); }
+        if (peg$silentFails === 0) { peg$fail(peg$c1); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 123) {
-            s4 = peg$c3;
+            s4 = peg$c2;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c4); }
+            if (peg$silentFails === 0) { peg$fail(peg$c3); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -435,11 +415,11 @@ function peg$parse(input, options) {
                     s9 = peg$parse_();
                     if (s9 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 125) {
-                        s10 = peg$c5;
+                        s10 = peg$c4;
                         peg$currPos++;
                       } else {
                         s10 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c6); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c5); }
                       }
                       if (s10 !== peg$FAILED) {
                         s11 = peg$parse_();
@@ -452,7 +432,7 @@ function peg$parse(input, options) {
                           }
                           if (s12 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c7(s7, s8);
+                            s1 = peg$c6(s7, s8);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -502,11 +482,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c0); }
-    }
 
     return s0;
   }
@@ -514,26 +489,25 @@ function peg$parse(input, options) {
   function peg$parsecode_block() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c9) {
-        s2 = peg$c9;
+      if (input.substr(peg$currPos, 4) === peg$c7) {
+        s2 = peg$c7;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c10); }
+        if (peg$silentFails === 0) { peg$fail(peg$c8); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 123) {
-            s4 = peg$c3;
+            s4 = peg$c2;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c4); }
+            if (peg$silentFails === 0) { peg$fail(peg$c3); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -554,11 +528,11 @@ function peg$parse(input, options) {
                   s8 = peg$parse_();
                   if (s8 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 125) {
-                      s9 = peg$c5;
+                      s9 = peg$c4;
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c6); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c5); }
                     }
                     if (s9 !== peg$FAILED) {
                       s10 = peg$parse_();
@@ -566,7 +540,7 @@ function peg$parse(input, options) {
                         s11 = peg$parsenewline();
                         if (s11 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c11(s7);
+                          s1 = peg$c9(s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -612,11 +586,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c8); }
-    }
 
     return s0;
   }
@@ -624,7 +593,6 @@ function peg$parse(input, options) {
   function peg$parsecode_block_line() {
     var s0, s1, s2, s3, s4;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
@@ -635,7 +603,7 @@ function peg$parse(input, options) {
           s4 = peg$parsenewline();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c13(s2);
+            s1 = peg$c10(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -653,11 +621,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c12); }
-    }
 
     return s0;
   }
@@ -665,25 +628,24 @@ function peg$parse(input, options) {
   function peg$parsecode() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c15.test(input.charAt(peg$currPos))) {
+    if (peg$c11.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c16); }
+      if (peg$silentFails === 0) { peg$fail(peg$c12); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c15.test(input.charAt(peg$currPos))) {
+        if (peg$c11.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c16); }
+          if (peg$silentFails === 0) { peg$fail(peg$c12); }
         }
       }
     } else {
@@ -694,11 +656,6 @@ function peg$parse(input, options) {
     } else {
       s0 = s1;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c14); }
-    }
 
     return s0;
   }
@@ -706,26 +663,25 @@ function peg$parse(input, options) {
   function peg$parseoutput_block() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c18) {
-        s2 = peg$c18;
+      if (input.substr(peg$currPos, 6) === peg$c13) {
+        s2 = peg$c13;
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c19); }
+        if (peg$silentFails === 0) { peg$fail(peg$c14); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 123) {
-            s4 = peg$c3;
+            s4 = peg$c2;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c4); }
+            if (peg$silentFails === 0) { peg$fail(peg$c3); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -733,11 +689,11 @@ function peg$parse(input, options) {
               s6 = peg$parsenewline();
               if (s6 !== peg$FAILED) {
                 s7 = [];
-                s8 = peg$parseoutput_block_element();
+                s8 = peg$parseoutput_line();
                 if (s8 !== peg$FAILED) {
                   while (s8 !== peg$FAILED) {
                     s7.push(s8);
-                    s8 = peg$parseoutput_block_element();
+                    s8 = peg$parseoutput_line();
                   }
                 } else {
                   s7 = peg$FAILED;
@@ -746,11 +702,11 @@ function peg$parse(input, options) {
                   s8 = peg$parse_();
                   if (s8 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 125) {
-                      s9 = peg$c5;
+                      s9 = peg$c4;
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c6); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c5); }
                     }
                     if (s9 !== peg$FAILED) {
                       s10 = peg$parse_();
@@ -758,7 +714,7 @@ function peg$parse(input, options) {
                         s11 = peg$parsenewline();
                         if (s11 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c20(s7);
+                          s1 = peg$c15(s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -804,25 +760,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c17); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseoutput_block_element() {
-    var s0, s1;
-
-    peg$silentFails++;
-    s0 = peg$parseoutput_line();
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c21); }
-    }
 
     return s0;
   }
@@ -830,16 +767,15 @@ function peg$parse(input, options) {
   function peg$parseoutput_line() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 39) {
-        s2 = peg$c23;
+        s2 = peg$c16;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c24); }
+        if (peg$silentFails === 0) { peg$fail(peg$c17); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
@@ -868,11 +804,11 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s4 = peg$c23;
+            s4 = peg$c16;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c24); }
+            if (peg$silentFails === 0) { peg$fail(peg$c17); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -880,7 +816,7 @@ function peg$parse(input, options) {
               s6 = peg$parsenewline();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c25(s3);
+                s1 = peg$c18(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -911,11 +847,11 @@ function peg$parse(input, options) {
       s1 = peg$parse_();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s2 = peg$c26;
+          s2 = peg$c19;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c27); }
+          if (peg$silentFails === 0) { peg$fail(peg$c20); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
@@ -944,11 +880,11 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 34) {
-              s4 = peg$c26;
+              s4 = peg$c19;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c27); }
+              if (peg$silentFails === 0) { peg$fail(peg$c20); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -956,7 +892,7 @@ function peg$parse(input, options) {
                 s6 = peg$parsenewline();
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c25(s3);
+                  s1 = peg$c18(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -983,11 +919,6 @@ function peg$parse(input, options) {
         s0 = peg$FAILED;
       }
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c22); }
-    }
 
     return s0;
   }
@@ -995,7 +926,6 @@ function peg$parse(input, options) {
   function peg$parseitem_code() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parseplaceholder_open();
     if (s1 !== peg$FAILED) {
@@ -1003,12 +933,12 @@ function peg$parse(input, options) {
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 4) === peg$c9) {
-            s4 = peg$c9;
+          if (input.substr(peg$currPos, 4) === peg$c7) {
+            s4 = peg$c7;
             peg$currPos += 4;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c10); }
+            if (peg$silentFails === 0) { peg$fail(peg$c8); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -1016,7 +946,7 @@ function peg$parse(input, options) {
               s6 = peg$parsebracket_close();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c29();
+                s1 = peg$c21();
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1041,11 +971,6 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c28); }
     }
 
     return s0;
@@ -1054,7 +979,6 @@ function peg$parse(input, options) {
   function peg$parseitem_name() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parseplaceholder_open();
     if (s1 !== peg$FAILED) {
@@ -1062,12 +986,12 @@ function peg$parse(input, options) {
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 4) === peg$c31) {
-            s4 = peg$c31;
+          if (input.substr(peg$currPos, 4) === peg$c22) {
+            s4 = peg$c22;
             peg$currPos += 4;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c32); }
+            if (peg$silentFails === 0) { peg$fail(peg$c23); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -1075,7 +999,7 @@ function peg$parse(input, options) {
               s6 = peg$parsebracket_close();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c33();
+                s1 = peg$c24();
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1100,11 +1024,6 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c30); }
     }
 
     return s0;
@@ -1113,7 +1032,6 @@ function peg$parse(input, options) {
   function peg$parseitem_amount() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parseplaceholder_open();
     if (s1 !== peg$FAILED) {
@@ -1121,12 +1039,12 @@ function peg$parse(input, options) {
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c35) {
-            s4 = peg$c35;
+          if (input.substr(peg$currPos, 6) === peg$c25) {
+            s4 = peg$c25;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c36); }
+            if (peg$silentFails === 0) { peg$fail(peg$c26); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -1134,7 +1052,7 @@ function peg$parse(input, options) {
               s6 = peg$parsebracket_close();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c37();
+                s1 = peg$c27();
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1160,11 +1078,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c34); }
-    }
 
     return s0;
   }
@@ -1172,18 +1085,17 @@ function peg$parse(input, options) {
   function peg$parseplaceholder_open() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     if (input.length > peg$currPos) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c39); }
+      if (peg$silentFails === 0) { peg$fail(peg$c28); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c40(s1);
+      s2 = peg$c29(s1);
       if (s2) {
         s2 = void 0;
       } else {
@@ -1191,7 +1103,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c41(s1);
+        s1 = peg$c30(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1200,11 +1112,6 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c38); }
     }
 
     return s0;
@@ -1213,18 +1120,17 @@ function peg$parse(input, options) {
   function peg$parsebracket_open() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     if (input.length > peg$currPos) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c39); }
+      if (peg$silentFails === 0) { peg$fail(peg$c28); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c43(s1);
+      s2 = peg$c31(s1);
       if (s2) {
         s2 = void 0;
       } else {
@@ -1232,7 +1138,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c41(s1);
+        s1 = peg$c30(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1241,11 +1147,6 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c42); }
     }
 
     return s0;
@@ -1254,18 +1155,17 @@ function peg$parse(input, options) {
   function peg$parsebracket_close() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     if (input.length > peg$currPos) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c39); }
+      if (peg$silentFails === 0) { peg$fail(peg$c28); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c45(s1);
+      s2 = peg$c32(s1);
       if (s2) {
         s2 = void 0;
       } else {
@@ -1273,7 +1173,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c41(s1);
+        s1 = peg$c30(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1283,11 +1183,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c44); }
-    }
 
     return s0;
   }
@@ -1295,7 +1190,6 @@ function peg$parse(input, options) {
   function peg$parsetext_single_quote() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = [];
     s2 = peg$parsetext_single_quote_char();
@@ -1309,14 +1203,9 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c47(s1);
+      s1 = peg$c33(s1);
     }
     s0 = s1;
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c46); }
-    }
 
     return s0;
   }
@@ -1324,18 +1213,17 @@ function peg$parse(input, options) {
   function peg$parsetext_single_quote_char() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
-    if (peg$c49.test(input.charAt(peg$currPos))) {
+    if (peg$c34.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c50); }
+      if (peg$silentFails === 0) { peg$fail(peg$c35); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c51(s1);
+      s2 = peg$c36(s1);
       if (s2) {
         s2 = void 0;
       } else {
@@ -1343,7 +1231,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c52(s1);
+        s1 = peg$c37(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1353,11 +1241,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c48); }
-    }
 
     return s0;
   }
@@ -1365,7 +1248,6 @@ function peg$parse(input, options) {
   function peg$parsetext_double_quote() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = [];
     s2 = peg$parsetext_double_quote_char();
@@ -1379,14 +1261,9 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c47(s1);
+      s1 = peg$c33(s1);
     }
     s0 = s1;
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c53); }
-    }
 
     return s0;
   }
@@ -1394,18 +1271,17 @@ function peg$parse(input, options) {
   function peg$parsetext_double_quote_char() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
-    if (peg$c55.test(input.charAt(peg$currPos))) {
+    if (peg$c38.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c56); }
+      if (peg$silentFails === 0) { peg$fail(peg$c39); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c51(s1);
+      s2 = peg$c36(s1);
       if (s2) {
         s2 = void 0;
       } else {
@@ -1413,7 +1289,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c52(s1);
+        s1 = peg$c37(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1423,11 +1299,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
-    }
 
     return s0;
   }
@@ -1435,29 +1306,23 @@ function peg$parse(input, options) {
   function peg$parse_() {
     var s0, s1;
 
-    peg$silentFails++;
     s0 = [];
-    if (peg$c58.test(input.charAt(peg$currPos))) {
+    if (peg$c40.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c59); }
+      if (peg$silentFails === 0) { peg$fail(peg$c41); }
     }
     while (s1 !== peg$FAILED) {
       s0.push(s1);
-      if (peg$c58.test(input.charAt(peg$currPos))) {
+      if (peg$c40.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c59); }
+        if (peg$silentFails === 0) { peg$fail(peg$c41); }
       }
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c57); }
     }
 
     return s0;
@@ -1466,33 +1331,27 @@ function peg$parse(input, options) {
   function peg$parsenewline() {
     var s0, s1;
 
-    peg$silentFails++;
     s0 = [];
-    if (peg$c61.test(input.charAt(peg$currPos))) {
+    if (peg$c42.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c62); }
+      if (peg$silentFails === 0) { peg$fail(peg$c43); }
     }
     if (s1 !== peg$FAILED) {
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c61.test(input.charAt(peg$currPos))) {
+        if (peg$c42.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c62); }
+          if (peg$silentFails === 0) { peg$fail(peg$c43); }
         }
       }
     } else {
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c60); }
     }
 
     return s0;

--- a/src/reporting2/format2.pegjs
+++ b/src/reporting2/format2.pegjs
@@ -7,7 +7,7 @@
 start
   = report+
 
-report 'report'
+report
   = _ 'report' _ '{' _ newline
     codes:code_block
     outputs:output_block
@@ -19,7 +19,7 @@ report 'report'
     };
   }
 
-code_block 'code_block'
+code_block
   = _ 'code' _ '{' _ newline
     codes:code_block_line+
     _ '}' _ newline
@@ -27,16 +27,16 @@ code_block 'code_block'
     return codes;
   }
 
-code_block_line 'code_block_line'
+code_block_line
   = _ c:code _ newline
   {
     return c;
   }
 
-code 'code'
+code
   = $([0-9]+)
 
-output_block 'output_block'
+output_block
   = _ 'output' _ '{' _ newline
     outputs:output_block_element+
     _ '}' _ newline
@@ -44,10 +44,10 @@ output_block 'output_block'
     return outputs;
   }
 
-output_block_element 'output_block_element'
+output_block_element
   = output_line
 
-output_line 'output_line'
+output_line
   = _ "'" t:(item_code / item_name / item_amount / text_single_quote)* "'" _ newline
   {
     return {
@@ -65,7 +65,7 @@ output_line 'output_line'
     };
   }
 
-item_code 'item_code'
+item_code
   = placeholder_open bracket_open _ 'code' _ bracket_close
   {
     return {
@@ -74,7 +74,7 @@ item_code 'item_code'
     };
   }
 
-item_name 'item_name'
+item_name
   = placeholder_open bracket_open _ 'name' _ bracket_close
   {
     return {
@@ -83,7 +83,7 @@ item_name 'item_name'
     };
   }
 
-item_amount 'item_amount'
+item_amount
   = placeholder_open bracket_open _ 'amount' _ bracket_close
   {
     return {
@@ -92,28 +92,28 @@ item_amount 'item_amount'
     };
   }
 
-placeholder_open 'placeholder_open'
+placeholder_open
   = w:.
     &{ return w === placeholder_mark; }
   {
     return w;
   }
 
-bracket_open 'bracket_open'
+bracket_open
   = w:.
     &{ return w === bracket_open; }
   {
     return w;
   }
 
-bracket_close 'bracket_close'
+bracket_close
   = w:.
     &{ return w === bracket_close; }
   {
     return w;
   }
 
-text_single_quote 'text_single_quote'
+text_single_quote
   = chars:text_single_quote_char+
   {
     return {
@@ -122,14 +122,14 @@ text_single_quote 'text_single_quote'
     };
   }
 
-text_single_quote_char 'text_single_quote_char'
+text_single_quote_char
   = char:[^\r\n']
     &{ return char !== placeholder_mark; }
   {
     return char;
   }
 
-text_double_quote 'text_double_quote'
+text_double_quote
   = chars:text_double_quote_char+
   {
     return {
@@ -138,15 +138,15 @@ text_double_quote 'text_double_quote'
     };
   }
 
-text_double_quote_char 'text_double_quote_char'
+text_double_quote_char
   = char:[^\r\n"]
     &{ return char !== placeholder_mark; }
   {
     return char;
   }
 
-_ 'whitespace'
+_
   = [ \t]*
 
-newline 'newline'
+newline
   = [\r\n]+

--- a/src/reporting3/format3.js
+++ b/src/reporting3/format3.js
@@ -141,61 +141,53 @@ function peg$parse(input, options) {
       peg$startRuleFunctions = { start: peg$parsestart },
       peg$startRuleFunction  = peg$parsestart,
 
-      peg$c0 = peg$otherExpectation("report"),
-      peg$c1 = "report",
-      peg$c2 = peg$literalExpectation("report", false),
-      peg$c3 = "{",
-      peg$c4 = peg$literalExpectation("{", false),
-      peg$c5 = "}",
-      peg$c6 = peg$literalExpectation("}", false),
-      peg$c7 = function(codes, outputs) {
+      peg$c0 = "report",
+      peg$c1 = peg$literalExpectation("report", false),
+      peg$c2 = "{",
+      peg$c3 = peg$literalExpectation("{", false),
+      peg$c4 = "}",
+      peg$c5 = peg$literalExpectation("}", false),
+      peg$c6 = function(codes, outputs) {
           return {
             code: codes,
             output: outputs,
           };
         },
-      peg$c8 = peg$otherExpectation("code_block"),
-      peg$c9 = "code",
-      peg$c10 = peg$literalExpectation("code", false),
-      peg$c11 = function(codes) {
+      peg$c7 = "code",
+      peg$c8 = peg$literalExpectation("code", false),
+      peg$c9 = function(codes) {
           return codes;
         },
-      peg$c12 = peg$otherExpectation("code_block_line"),
-      peg$c13 = function(c) {
+      peg$c10 = function(c) {
           return c;
         },
-      peg$c14 = peg$otherExpectation("code"),
-      peg$c15 = /^[0-9]/,
-      peg$c16 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c17 = peg$otherExpectation("output_block"),
-      peg$c18 = "output",
-      peg$c19 = peg$literalExpectation("output", false),
-      peg$c20 = function(outputs) {
+      peg$c11 = /^[0-9]/,
+      peg$c12 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c13 = "output",
+      peg$c14 = peg$literalExpectation("output", false),
+      peg$c15 = function(outputs) {
           return outputs;
         },
-      peg$c21 = peg$otherExpectation("output_block_element"),
-      peg$c22 = peg$otherExpectation("output_line"),
-      peg$c23 = "'",
-      peg$c24 = peg$literalExpectation("'", false),
-      peg$c25 = function(t) {
+      peg$c16 = "'",
+      peg$c17 = peg$literalExpectation("'", false),
+      peg$c18 = function(t) {
           return {
             type: 'builtin',
             text: 'output_line',
             children: t,
           };
         },
-      peg$c26 = "\"",
-      peg$c27 = peg$literalExpectation("\"", false),
-      peg$c28 = peg$otherExpectation("for_loop"),
-      peg$c29 = "for",
-      peg$c30 = peg$literalExpectation("for", false),
-      peg$c31 = "(",
-      peg$c32 = peg$literalExpectation("(", false),
-      peg$c33 = "in",
-      peg$c34 = peg$literalExpectation("in", false),
-      peg$c35 = ")",
-      peg$c36 = peg$literalExpectation(")", false),
-      peg$c37 = function(v, a, children) {
+      peg$c19 = "\"",
+      peg$c20 = peg$literalExpectation("\"", false),
+      peg$c21 = "for",
+      peg$c22 = peg$literalExpectation("for", false),
+      peg$c23 = "(",
+      peg$c24 = peg$literalExpectation("(", false),
+      peg$c25 = "in",
+      peg$c26 = peg$literalExpectation("in", false),
+      peg$c27 = ")",
+      peg$c28 = peg$literalExpectation(")", false),
+      peg$c29 = function(v, a, children) {
           return {
             type: 'builtin',
             text: 'for_loop',
@@ -204,56 +196,44 @@ function peg$parse(input, options) {
             children: children,
           };
         },
-      peg$c38 = peg$otherExpectation("variable_output"),
-      peg$c39 = function(v) {
+      peg$c30 = function(v) {
           return v;
         },
-      peg$c40 = peg$otherExpectation("variable"),
-      peg$c41 = /^[a-z]/,
-      peg$c42 = peg$classExpectation([["a", "z"]], false, false),
-      peg$c43 = /^[0-9a-z_]/,
-      peg$c44 = peg$classExpectation([["0", "9"], ["a", "z"], "_"], false, false),
-      peg$c45 = function(head, tail) {
+      peg$c31 = /^[a-z]/,
+      peg$c32 = peg$classExpectation([["a", "z"]], false, false),
+      peg$c33 = /^[0-9a-z_]/,
+      peg$c34 = peg$classExpectation([["0", "9"], ["a", "z"], "_"], false, false),
+      peg$c35 = function(head, tail) {
           return {
             type: 'variable',
             text: head + tail.join(''),
           };
         },
-      peg$c46 = peg$otherExpectation("placeholder_open"),
-      peg$c47 = peg$anyExpectation(),
-      peg$c48 = function(w) { return w === placeholder_mark; },
-      peg$c49 = function(w) {
+      peg$c36 = peg$anyExpectation(),
+      peg$c37 = function(w) { return w === placeholder_mark; },
+      peg$c38 = function(w) {
           return w;
         },
-      peg$c50 = peg$otherExpectation("bracket_open"),
-      peg$c51 = function(w) { return w === bracket_open; },
-      peg$c52 = peg$otherExpectation("bracket_close"),
-      peg$c53 = function(w) { return w === bracket_close; },
-      peg$c54 = peg$otherExpectation("text_single_quote"),
-      peg$c55 = function(chars) {
+      peg$c39 = function(w) { return w === bracket_open; },
+      peg$c40 = function(w) { return w === bracket_close; },
+      peg$c41 = function(chars) {
           return {
             type: 'plain',
             text: chars.join(''),
           };
         },
-      peg$c56 = peg$otherExpectation("text_single_quote_char"),
-      peg$c57 = /^[^\r\n']/,
-      peg$c58 = peg$classExpectation(["\r", "\n", "'"], true, false),
-      peg$c59 = function(char) { return char !== placeholder_mark; },
-      peg$c60 = function(char) {
+      peg$c42 = /^[^\r\n']/,
+      peg$c43 = peg$classExpectation(["\r", "\n", "'"], true, false),
+      peg$c44 = function(char) { return char !== placeholder_mark; },
+      peg$c45 = function(char) {
           return char;
         },
-      peg$c61 = peg$otherExpectation("text_double_quote"),
-      peg$c62 = peg$otherExpectation("text_double_quote_char"),
-      peg$c63 = /^[^\r\n"]/,
-      peg$c64 = peg$classExpectation(["\r", "\n", "\""], true, false),
-      peg$c65 = peg$otherExpectation("whitespace"),
-      peg$c66 = /^[ \t]/,
-      peg$c67 = peg$classExpectation([" ", "\t"], false, false),
-      peg$c68 = peg$otherExpectation("space"),
-      peg$c69 = peg$otherExpectation("newline"),
-      peg$c70 = /^[\r\n]/,
-      peg$c71 = peg$classExpectation(["\r", "\n"], false, false),
+      peg$c46 = /^[^\r\n"]/,
+      peg$c47 = peg$classExpectation(["\r", "\n", "\""], true, false),
+      peg$c48 = /^[ \t]/,
+      peg$c49 = peg$classExpectation([" ", "\t"], false, false),
+      peg$c50 = /^[\r\n]/,
+      peg$c51 = peg$classExpectation(["\r", "\n"], false, false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -411,26 +391,25 @@ function peg$parse(input, options) {
   function peg$parsereport() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c1) {
-        s2 = peg$c1;
+      if (input.substr(peg$currPos, 6) === peg$c0) {
+        s2 = peg$c0;
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c2); }
+        if (peg$silentFails === 0) { peg$fail(peg$c1); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 123) {
-            s4 = peg$c3;
+            s4 = peg$c2;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c4); }
+            if (peg$silentFails === 0) { peg$fail(peg$c3); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -444,11 +423,11 @@ function peg$parse(input, options) {
                     s9 = peg$parse_();
                     if (s9 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 125) {
-                        s10 = peg$c5;
+                        s10 = peg$c4;
                         peg$currPos++;
                       } else {
                         s10 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c6); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c5); }
                       }
                       if (s10 !== peg$FAILED) {
                         s11 = peg$parse_();
@@ -461,7 +440,7 @@ function peg$parse(input, options) {
                           }
                           if (s12 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c7(s7, s8);
+                            s1 = peg$c6(s7, s8);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -511,11 +490,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c0); }
-    }
 
     return s0;
   }
@@ -523,26 +497,25 @@ function peg$parse(input, options) {
   function peg$parsecode_block() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c9) {
-        s2 = peg$c9;
+      if (input.substr(peg$currPos, 4) === peg$c7) {
+        s2 = peg$c7;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c10); }
+        if (peg$silentFails === 0) { peg$fail(peg$c8); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 123) {
-            s4 = peg$c3;
+            s4 = peg$c2;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c4); }
+            if (peg$silentFails === 0) { peg$fail(peg$c3); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -563,11 +536,11 @@ function peg$parse(input, options) {
                   s8 = peg$parse_();
                   if (s8 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 125) {
-                      s9 = peg$c5;
+                      s9 = peg$c4;
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c6); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c5); }
                     }
                     if (s9 !== peg$FAILED) {
                       s10 = peg$parse_();
@@ -575,7 +548,7 @@ function peg$parse(input, options) {
                         s11 = peg$parsenewline();
                         if (s11 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c11(s7);
+                          s1 = peg$c9(s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -621,11 +594,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c8); }
-    }
 
     return s0;
   }
@@ -633,7 +601,6 @@ function peg$parse(input, options) {
   function peg$parsecode_block_line() {
     var s0, s1, s2, s3, s4;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
@@ -644,7 +611,7 @@ function peg$parse(input, options) {
           s4 = peg$parsenewline();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c13(s2);
+            s1 = peg$c10(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -662,11 +629,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c12); }
-    }
 
     return s0;
   }
@@ -674,25 +636,24 @@ function peg$parse(input, options) {
   function peg$parsecode() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c15.test(input.charAt(peg$currPos))) {
+    if (peg$c11.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c16); }
+      if (peg$silentFails === 0) { peg$fail(peg$c12); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c15.test(input.charAt(peg$currPos))) {
+        if (peg$c11.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c16); }
+          if (peg$silentFails === 0) { peg$fail(peg$c12); }
         }
       }
     } else {
@@ -703,68 +664,74 @@ function peg$parse(input, options) {
     } else {
       s0 = s1;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c14); }
-    }
 
     return s0;
   }
 
   function peg$parseoutput_block() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c18) {
-        s2 = peg$c18;
+      if (input.substr(peg$currPos, 6) === peg$c13) {
+        s2 = peg$c13;
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c19); }
+        if (peg$silentFails === 0) { peg$fail(peg$c14); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 123) {
-            s4 = peg$c3;
+            s4 = peg$c2;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c4); }
+            if (peg$silentFails === 0) { peg$fail(peg$c3); }
           }
           if (s4 !== peg$FAILED) {
-            s5 = peg$parsenewline();
+            s5 = peg$parse_();
             if (s5 !== peg$FAILED) {
-              s6 = [];
-              s7 = peg$parseoutput_block_element();
-              if (s7 !== peg$FAILED) {
-                while (s7 !== peg$FAILED) {
-                  s6.push(s7);
-                  s7 = peg$parseoutput_block_element();
-                }
-              } else {
-                s6 = peg$FAILED;
-              }
+              s6 = peg$parsenewline();
               if (s6 !== peg$FAILED) {
-                s7 = peg$parse_();
-                if (s7 !== peg$FAILED) {
-                  if (input.charCodeAt(peg$currPos) === 125) {
-                    s8 = peg$c5;
-                    peg$currPos++;
-                  } else {
-                    s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c6); }
+                s7 = [];
+                s8 = peg$parseoutput_block_element();
+                if (s8 !== peg$FAILED) {
+                  while (s8 !== peg$FAILED) {
+                    s7.push(s8);
+                    s8 = peg$parseoutput_block_element();
                   }
+                } else {
+                  s7 = peg$FAILED;
+                }
+                if (s7 !== peg$FAILED) {
+                  s8 = peg$parse_();
                   if (s8 !== peg$FAILED) {
-                    s9 = peg$parsenewline();
+                    if (input.charCodeAt(peg$currPos) === 125) {
+                      s9 = peg$c4;
+                      peg$currPos++;
+                    } else {
+                      s9 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c5); }
+                    }
                     if (s9 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c20(s6);
-                      s0 = s1;
+                      s10 = peg$parse_();
+                      if (s10 !== peg$FAILED) {
+                        s11 = peg$parsenewline();
+                        if (s11 !== peg$FAILED) {
+                          peg$savedPos = s0;
+                          s1 = peg$c15(s7);
+                          s0 = s1;
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
                     } else {
                       peg$currPos = s0;
                       s0 = peg$FAILED;
@@ -801,27 +768,16 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c17); }
-    }
 
     return s0;
   }
 
   function peg$parseoutput_block_element() {
-    var s0, s1;
+    var s0;
 
-    peg$silentFails++;
     s0 = peg$parseoutput_line();
     if (s0 === peg$FAILED) {
       s0 = peg$parsefor_loop();
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c21); }
     }
 
     return s0;
@@ -830,16 +786,15 @@ function peg$parse(input, options) {
   function peg$parseoutput_line() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 39) {
-        s2 = peg$c23;
+        s2 = peg$c16;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c24); }
+        if (peg$silentFails === 0) { peg$fail(peg$c17); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
@@ -856,11 +811,11 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s4 = peg$c23;
+            s4 = peg$c16;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c24); }
+            if (peg$silentFails === 0) { peg$fail(peg$c17); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -868,7 +823,7 @@ function peg$parse(input, options) {
               s6 = peg$parsenewline();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c25(s3);
+                s1 = peg$c18(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -899,11 +854,11 @@ function peg$parse(input, options) {
       s1 = peg$parse_();
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s2 = peg$c26;
+          s2 = peg$c19;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c27); }
+          if (peg$silentFails === 0) { peg$fail(peg$c20); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
@@ -920,11 +875,11 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 34) {
-              s4 = peg$c26;
+              s4 = peg$c19;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c27); }
+              if (peg$silentFails === 0) { peg$fail(peg$c20); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -932,7 +887,7 @@ function peg$parse(input, options) {
                 s6 = peg$parsenewline();
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c25(s3);
+                  s1 = peg$c18(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -959,11 +914,6 @@ function peg$parse(input, options) {
         s0 = peg$FAILED;
       }
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c22); }
-    }
 
     return s0;
   }
@@ -971,26 +921,25 @@ function peg$parse(input, options) {
   function peg$parsefor_loop() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c29) {
-        s2 = peg$c29;
+      if (input.substr(peg$currPos, 3) === peg$c21) {
+        s2 = peg$c21;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c30); }
+        if (peg$silentFails === 0) { peg$fail(peg$c22); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c31;
+            s4 = peg$c23;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c32); }
+            if (peg$silentFails === 0) { peg$fail(peg$c24); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -999,12 +948,12 @@ function peg$parse(input, options) {
               if (s6 !== peg$FAILED) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c33) {
-                    s8 = peg$c33;
+                  if (input.substr(peg$currPos, 2) === peg$c25) {
+                    s8 = peg$c25;
                     peg$currPos += 2;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c34); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c26); }
                   }
                   if (s8 !== peg$FAILED) {
                     s9 = peg$parse__();
@@ -1014,21 +963,21 @@ function peg$parse(input, options) {
                         s11 = peg$parse_();
                         if (s11 !== peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 41) {
-                            s12 = peg$c35;
+                            s12 = peg$c27;
                             peg$currPos++;
                           } else {
                             s12 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c36); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c28); }
                           }
                           if (s12 !== peg$FAILED) {
                             s13 = peg$parse_();
                             if (s13 !== peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 123) {
-                                s14 = peg$c3;
+                                s14 = peg$c2;
                                 peg$currPos++;
                               } else {
                                 s14 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c4); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c3); }
                               }
                               if (s14 !== peg$FAILED) {
                                 s15 = peg$parse_();
@@ -1049,11 +998,11 @@ function peg$parse(input, options) {
                                       s18 = peg$parse_();
                                       if (s18 !== peg$FAILED) {
                                         if (input.charCodeAt(peg$currPos) === 125) {
-                                          s19 = peg$c5;
+                                          s19 = peg$c4;
                                           peg$currPos++;
                                         } else {
                                           s19 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c6); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c5); }
                                         }
                                         if (s19 !== peg$FAILED) {
                                           s20 = peg$parse_();
@@ -1061,7 +1010,7 @@ function peg$parse(input, options) {
                                             s21 = peg$parsenewline();
                                             if (s21 !== peg$FAILED) {
                                               peg$savedPos = s0;
-                                              s1 = peg$c37(s6, s10, s17);
+                                              s1 = peg$c29(s6, s10, s17);
                                               s0 = s1;
                                             } else {
                                               peg$currPos = s0;
@@ -1147,11 +1096,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c28); }
-    }
 
     return s0;
   }
@@ -1159,7 +1103,6 @@ function peg$parse(input, options) {
   function peg$parsevariable_output() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = peg$parseplaceholder_open();
     if (s1 !== peg$FAILED) {
@@ -1174,7 +1117,7 @@ function peg$parse(input, options) {
               s6 = peg$parsebracket_close();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c39(s4);
+                s1 = peg$c30(s4);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1200,11 +1143,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c38); }
-    }
 
     return s0;
   }
@@ -1212,37 +1150,36 @@ function peg$parse(input, options) {
   function peg$parsevariable() {
     var s0, s1, s2, s3;
 
-    peg$silentFails++;
     s0 = peg$currPos;
-    if (peg$c41.test(input.charAt(peg$currPos))) {
+    if (peg$c31.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c42); }
+      if (peg$silentFails === 0) { peg$fail(peg$c32); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c43.test(input.charAt(peg$currPos))) {
+      if (peg$c33.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        if (peg$silentFails === 0) { peg$fail(peg$c34); }
       }
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        if (peg$c43.test(input.charAt(peg$currPos))) {
+        if (peg$c33.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c34); }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c45(s1, s2);
+        s1 = peg$c35(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1251,11 +1188,6 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c40); }
     }
 
     return s0;
@@ -1264,18 +1196,17 @@ function peg$parse(input, options) {
   function peg$parseplaceholder_open() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     if (input.length > peg$currPos) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c47); }
+      if (peg$silentFails === 0) { peg$fail(peg$c36); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c48(s1);
+      s2 = peg$c37(s1);
       if (s2) {
         s2 = void 0;
       } else {
@@ -1283,7 +1214,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c49(s1);
+        s1 = peg$c38(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1292,11 +1223,6 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c46); }
     }
 
     return s0;
@@ -1305,18 +1231,17 @@ function peg$parse(input, options) {
   function peg$parsebracket_open() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     if (input.length > peg$currPos) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c47); }
+      if (peg$silentFails === 0) { peg$fail(peg$c36); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c51(s1);
+      s2 = peg$c39(s1);
       if (s2) {
         s2 = void 0;
       } else {
@@ -1324,7 +1249,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c49(s1);
+        s1 = peg$c38(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1333,11 +1258,6 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c50); }
     }
 
     return s0;
@@ -1346,18 +1266,17 @@ function peg$parse(input, options) {
   function peg$parsebracket_close() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     if (input.length > peg$currPos) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c47); }
+      if (peg$silentFails === 0) { peg$fail(peg$c36); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c53(s1);
+      s2 = peg$c40(s1);
       if (s2) {
         s2 = void 0;
       } else {
@@ -1365,7 +1284,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c49(s1);
+        s1 = peg$c38(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1375,11 +1294,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c52); }
-    }
 
     return s0;
   }
@@ -1387,7 +1301,6 @@ function peg$parse(input, options) {
   function peg$parsetext_single_quote() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = [];
     s2 = peg$parsetext_single_quote_char();
@@ -1401,14 +1314,9 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c55(s1);
+      s1 = peg$c41(s1);
     }
     s0 = s1;
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c54); }
-    }
 
     return s0;
   }
@@ -1416,18 +1324,17 @@ function peg$parse(input, options) {
   function peg$parsetext_single_quote_char() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
-    if (peg$c57.test(input.charAt(peg$currPos))) {
+    if (peg$c42.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c58); }
+      if (peg$silentFails === 0) { peg$fail(peg$c43); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c59(s1);
+      s2 = peg$c44(s1);
       if (s2) {
         s2 = void 0;
       } else {
@@ -1435,7 +1342,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c60(s1);
+        s1 = peg$c45(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1445,11 +1352,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c56); }
-    }
 
     return s0;
   }
@@ -1457,7 +1359,6 @@ function peg$parse(input, options) {
   function peg$parsetext_double_quote() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
     s1 = [];
     s2 = peg$parsetext_double_quote_char();
@@ -1471,14 +1372,9 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c55(s1);
+      s1 = peg$c41(s1);
     }
     s0 = s1;
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c61); }
-    }
 
     return s0;
   }
@@ -1486,18 +1382,17 @@ function peg$parse(input, options) {
   function peg$parsetext_double_quote_char() {
     var s0, s1, s2;
 
-    peg$silentFails++;
     s0 = peg$currPos;
-    if (peg$c63.test(input.charAt(peg$currPos))) {
+    if (peg$c46.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c64); }
+      if (peg$silentFails === 0) { peg$fail(peg$c47); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c59(s1);
+      s2 = peg$c44(s1);
       if (s2) {
         s2 = void 0;
       } else {
@@ -1505,7 +1400,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c60(s1);
+        s1 = peg$c45(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1515,11 +1410,6 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c62); }
-    }
 
     return s0;
   }
@@ -1527,29 +1417,23 @@ function peg$parse(input, options) {
   function peg$parse_() {
     var s0, s1;
 
-    peg$silentFails++;
     s0 = [];
-    if (peg$c66.test(input.charAt(peg$currPos))) {
+    if (peg$c48.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c67); }
+      if (peg$silentFails === 0) { peg$fail(peg$c49); }
     }
     while (s1 !== peg$FAILED) {
       s0.push(s1);
-      if (peg$c66.test(input.charAt(peg$currPos))) {
+      if (peg$c48.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c67); }
+        if (peg$silentFails === 0) { peg$fail(peg$c49); }
       }
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c65); }
     }
 
     return s0;
@@ -1558,33 +1442,27 @@ function peg$parse(input, options) {
   function peg$parse__() {
     var s0, s1;
 
-    peg$silentFails++;
     s0 = [];
-    if (peg$c66.test(input.charAt(peg$currPos))) {
+    if (peg$c48.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c67); }
+      if (peg$silentFails === 0) { peg$fail(peg$c49); }
     }
     if (s1 !== peg$FAILED) {
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c66.test(input.charAt(peg$currPos))) {
+        if (peg$c48.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c67); }
+          if (peg$silentFails === 0) { peg$fail(peg$c49); }
         }
       }
     } else {
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c68); }
     }
 
     return s0;
@@ -1593,33 +1471,27 @@ function peg$parse(input, options) {
   function peg$parsenewline() {
     var s0, s1;
 
-    peg$silentFails++;
     s0 = [];
-    if (peg$c70.test(input.charAt(peg$currPos))) {
+    if (peg$c50.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c71); }
+      if (peg$silentFails === 0) { peg$fail(peg$c51); }
     }
     if (s1 !== peg$FAILED) {
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c70.test(input.charAt(peg$currPos))) {
+        if (peg$c50.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c71); }
+          if (peg$silentFails === 0) { peg$fail(peg$c51); }
         }
       }
     } else {
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c69); }
     }
 
     return s0;

--- a/src/reporting3/format3.pegjs
+++ b/src/reporting3/format3.pegjs
@@ -7,7 +7,7 @@
 start
   = report+
 
-report 'report'
+report
   = _ 'report' _ '{' _ newline
     codes:code_block
     outputs:output_block
@@ -19,7 +19,7 @@ report 'report'
     };
   }
 
-code_block 'code_block'
+code_block
   = _ 'code' _ '{' _ newline
     codes:code_block_line+
     _ '}' _ newline
@@ -27,16 +27,16 @@ code_block 'code_block'
     return codes;
   }
 
-code_block_line 'code_block_line'
+code_block_line
   = _ c:code _ newline
   {
     return c;
   }
 
-code 'code'
+code
   = $([0-9]+)
 
-output_block 'output_block'
+output_block
   = _ 'output' _ '{' _ newline
     outputs:output_block_element+
     _ '}' _ newline
@@ -44,11 +44,11 @@ output_block 'output_block'
     return outputs;
   }
 
-output_block_element 'output_block_element'
+output_block_element
   = output_line
   / for_loop
 
-output_line 'output_line'
+output_line
   = _ "'" t:(variable_output / text_single_quote)* "'" _ newline
   {
     return {
@@ -66,7 +66,7 @@ output_line 'output_line'
     };
   }
 
-for_loop 'for_loop'
+for_loop
   = _ 'for' _ '(' _ v:variable __ 'in' __ a:variable _ ')' _ '{' _ newline
     children:output_block_element+
     _ '}' _ newline
@@ -80,13 +80,13 @@ for_loop 'for_loop'
     };
   }
 
-variable_output 'variable_output'
+variable_output
   = placeholder_open bracket_open _ v:variable _ bracket_close
   {
     return v;
   }
 
-variable 'variable'
+variable
   = head:[a-z] tail:[0-9a-z_]*
   {
     return {
@@ -95,28 +95,28 @@ variable 'variable'
     };
   }
 
-placeholder_open 'placeholder_open'
+placeholder_open
   = w:.
     &{ return w === placeholder_mark; }
   {
     return w;
   }
 
-bracket_open 'bracket_open'
+bracket_open
   = w:.
     &{ return w === bracket_open; }
   {
     return w;
   }
 
-bracket_close 'bracket_close'
+bracket_close
   = w:.
     &{ return w === bracket_close; }
   {
     return w;
   }
 
-text_single_quote 'text_single_quote'
+text_single_quote
   = chars:text_single_quote_char+
   {
     return {
@@ -125,14 +125,14 @@ text_single_quote 'text_single_quote'
     };
   }
 
-text_single_quote_char 'text_single_quote_char'
+text_single_quote_char
   = char:[^\r\n']
     &{ return char !== placeholder_mark; }
   {
     return char;
   }
 
-text_double_quote 'text_double_quote'
+text_double_quote
   = chars:text_double_quote_char+
   {
     return {
@@ -141,18 +141,18 @@ text_double_quote 'text_double_quote'
     };
   }
 
-text_double_quote_char 'text_double_quote_char'
+text_double_quote_char
   = char:[^\r\n"]
     &{ return char !== placeholder_mark; }
   {
     return char;
   }
 
-_ 'whitespace'
+_
   = [ \t]*
 
-__ 'space'
+__
   = [ \t]+
 
-newline 'newline'
+newline
   = [\r\n]+


### PR DESCRIPTION
## Related

- #6 

## Problem of rule name (example)

`src/placeholder/format1.pegjs`

### Text

```
{value1]
```

`]` should be `}`.

### Without rule name

```
start
  = placeholder

placeholder
  = _ delim_open:delim_open _ v:variable _ delim_close:delim_close
  {
    return [delim_open, v, delim_close];
  }
...
```

Error information:

```
  message: 'Expected [^ a-z0-9] but end of input found.',
  location: {
    start: { offset: 8, line: 1, column: 9 },
    end: { offset: 8, line: 1, column: 9 }
  },
```

### With rule name

```
start
  = placeholder

placeholder 'placeholder'
  = _ delim_open:delim_open _ v:variable _ delim_close:delim_close
  {
    return [delim_open, v, delim_close];
  }
...
```

Error information:

```
  message: 'Expected placeholder but "{" found.',
  location: {
    start: { offset: 0, line: 1, column: 1 },
    end: { offset: 1, line: 1, column: 2 }
  },
```

### Comparison

With rule name, parser does not consume part of tokens of the rule that can be parsed.
Parser handles the whole rule as an error.


## Additional note

As long as check behavior with `pegjs` (`0.10.0`),
it seems that rule name is helpful to display moderately human readable error message when:
- the rule has only terminated symbols.
- the rule has at most 1 nonterminal symbol.
